### PR TITLE
fix Unicode character issue for krull2024 rd file

### DIFF
--- a/R/krull2024.R
+++ b/R/krull2024.R
@@ -1,9 +1,9 @@
-##' Krull et al, 2024 (Nature Communications): IFN-γ response
+##' Krull et al, 2024 (Nature Communications): IFN-\eqn{\gamma} response
 ##'
 ##' They develop a new strategy for data-independent acquisition (DIA) that 
 ##' leverages the co-analysis of low-input samples alongside a corresponding 
 ##' enhancer (ME) of higher input. Using DIA-ME, they investigate the 
-##' proteomic response of U-2 OS cells to interferon gamma (IFN-y) at 
+##' proteomic response of U-2 OS cells to interferon gamma (IFN-\eqn{\gamma}) at 
 ##' the single-cell level.
 ##'
 ##' @format A [QFeatures] object with 159 assays, each assay being a
@@ -70,7 +70,7 @@
 ##'
 ##' @references
 ##' Krull, K. K., Ali, S. A., & Krijgsveld, J. 2024. "Enhanced feature matching
-##' in single-cell proteomics characterizes IFN-γ response and co-existence of
+##' in single-cell proteomics characterizes IFN-\eqn{\gamma} response and co-existence of
 ##' Cell States." Nature Communications, 15(1). 
 ##' [Link to article](https://doi.org/10.1038/s41467-024-52605-x) 
 ##' 

--- a/man/krull2024.Rd
+++ b/man/krull2024.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{krull2024}
 \alias{krull2024}
-\title{Krull et al, 2024 (Nature Communications): IFN-γ response}
+\title{Krull et al, 2024 (Nature Communications): IFN-\eqn{\gamma} response}
 \format{
 A \link{QFeatures} object with 159 assays, each assay being a
 \link{SingleCellExperiment} object.
@@ -34,7 +34,7 @@ krull2024
 They develop a new strategy for data-independent acquisition (DIA) that
 leverages the co-analysis of low-input samples alongside a corresponding
 enhancer (ME) of higher input. Using DIA-ME, they investigate the
-proteomic response of U-2 OS cells to interferon gamma (IFN-y) at
+proteomic response of U-2 OS cells to interferon gamma (IFN-\eqn{\gamma}) at
 the single-cell level.
 }
 \section{Acquisition protocol}{
@@ -91,7 +91,7 @@ krull2024()
 }
 \references{
 Krull, K. K., Ali, S. A., & Krijgsveld, J. 2024. "Enhanced feature matching
-in single-cell proteomics characterizes IFN-γ response and co-existence of
+in single-cell proteomics characterizes IFN-\eqn{\gamma} response and co-existence of
 Cell States." Nature Communications, 15(1).
 \href{https://doi.org/10.1038/s41467-024-52605-x}{Link to article}
 }


### PR DESCRIPTION
Hello,
The current version of scpdata does not pass the Build/Check report of Bioconductor due to an error when compiling the .rd files to pdf. The issue is the gamma unicode which is not recognized by latex. Here is a quick fix.